### PR TITLE
Bit of refactoring, and some fixes

### DIFF
--- a/lib/srt/formatter.ex
+++ b/lib/srt/formatter.ex
@@ -1,4 +1,4 @@
-defmodule Subtitles.SrtFormatter do
+defmodule Subtitles.Srt.Formatter do
   def format(%Subtitle{cues: cues}) do
     cues
     |> Enum.with_index(1)

--- a/lib/srt/parser.ex
+++ b/lib/srt/parser.ex
@@ -1,9 +1,11 @@
-defmodule Subtitles.SrtParser do
+defmodule Subtitles.Srt.Parser do
   def parse(subtitle) do
-    subtitle 
-    |> Utils.split_lines()
-    |> Enum.map(&parse_cue/1)
-    |> Subtitle.new()
+    subs = subtitle
+      |> Utils.split_lines()
+      |> Enum.map(&parse_cue/1)
+      |> Subtitle.new()
+
+    {:ok, subs}
   end
 
   defp parse_cue(cue), do: cue |> String.split("\n", trim: true) |> make_subtitle()

--- a/lib/subtitles.ex
+++ b/lib/subtitles.ex
@@ -1,21 +1,50 @@
 defmodule Subtitles do
-  alias Subtitles.VttParser
-  alias Subtitles.SrtParser
+  defmodule InputValidationFailure do
+    defexception message: "Input failed validation"
+  end
+
+  defmodule UnknownFormat.Parser do
+    def parse(_), do: {:error, "Unknown subtitle format"}
+  end
 
   @srt_cue_matcher ~r/\n?1\n(\d{2}:){2}\d{2},\d{3} --> (\d{2}:){2}\d{2},\d{3}(\n.+)+\n\n/
 
-  def get_format(subtitle) do
-    subtitle = subtitle |> Utils.normalize_line_endings()
+  def guess_format(subtitle), do: subtitle |> validate_input |> _guess_format
 
-    subtitle |> is_vtt?() && :vtt ||
-    subtitle |> is_srt?() && :srt ||
-    :unknown
+  def parse(subtitle) do
+    subtitle = subtitle |> validate_input
+
+    subtitle |> dispatch(guess_format(subtitle))
   end
 
-  def parse(subtitle), do: subtitle |> parse(get_format(subtitle))
-  def parse(subtitle, :vtt), do: {:ok, subtitle |> VttParser.parse()}
-  def parse(subtitle, :srt), do: {:ok, subtitle |> SrtParser.parse()}
-  def parse(_, :unknown), do: {:error, "Unknown subtitle format"}
+  def parse(subtitle, format) do
+    subtitle
+    |> validate_input
+    |> dispatch(format)
+  end
+
+  defp dispatch(subtitle, format) do
+    parser = Subtitles
+      |> Module.concat(format)
+      |> Module.concat(Parser)
+    parser.parse(subtitle)
+  end
+
+  def validate_input(subtitle) do
+    if not String.valid?(subtitle) do
+      raise InputValidationFailure, message: "Input was not valid UTF-8 string"
+    end
+
+    subtitle |> Utils.normalize_line_endings()
+  end
+
+  defp _guess_format(subtitle) do
+    cond do
+      subtitle |> is_vtt?() -> :Vtt
+      subtitle |> is_srt?() -> :Srt
+      true                  -> :UnknownFormat
+    end
+  end
 
   defp is_vtt?(subtitle), do: subtitle |> String.starts_with?("WEBVTT")
   defp is_srt?(subtitle), do: @srt_cue_matcher |> Regex.match?(subtitle)

--- a/lib/vtt/formatter.ex
+++ b/lib/vtt/formatter.ex
@@ -1,4 +1,4 @@
-defmodule Subtitles.VttFormatter do
+defmodule Subtitles.Vtt.Formatter do
   def format(%Subtitle{cues: cues}), do: "WEBVTT\n\n" <> build_cues(cues)
 
   defp build_cues(sub) do
@@ -13,7 +13,7 @@ defmodule Subtitles.VttFormatter do
   end
 
   defp build_cue_header(%{from: from, to: to}) do
-    "#{Utils.format_time(from, ".")} --> #{Utils.format_time(to, ".")}\n" 
+    "#{Utils.format_time(from, ".")} --> #{Utils.format_time(to, ".")}\n"
   end
 
   defp build_cue_text(parts), do: parts |> Enum.map(& &1.text_data) |> Enum.join("\n")

--- a/lib/vtt/parser.ex
+++ b/lib/vtt/parser.ex
@@ -1,13 +1,15 @@
-defmodule Subtitles.VttParser do
+defmodule Subtitles.Vtt.Parser do
   @time_pattern ~r/\d{2}:\d{2}:\d{2}\.\d{3}/
   @unsupported_blocks ["WEBVTT", "NOTE", "REGION", "STYLE"]
 
   def parse(subtitle) do
-    subtitle
-    |> Utils.split_lines()
-    |> filter_unsupported_blocks()
-    |> parse_cues()
-    |> Subtitle.new()
+    subs = subtitle
+      |> Utils.split_lines()
+      |> filter_unsupported_blocks()
+      |> parse_cues()
+      |> Subtitle.new()
+
+    {:ok, subs}
   end
 
   defp filter_unsupported_blocks(blocks) do

--- a/spec/srt/formatter_spec.exs
+++ b/spec/srt/formatter_spec.exs
@@ -1,10 +1,10 @@
-defmodule Subtitles.VttFormatterSpec do
+defmodule Subtitles.Srt.FormatterSpec do
   use ESpec
 
   describe "#format" do
-    subject do: sub() |> Subtitles.VttFormatter.format()
+    subject do: sub() |> Subtitles.Srt.Formatter.format()
 
-    let :expected, do: File.read!("spec/fixtures/format_test.vtt")
+    let :expected, do: File.read!("spec/fixtures/test.srt")
     let :sub, do: %Subtitle{
       cues: [
         %Cue{
@@ -52,3 +52,4 @@ defmodule Subtitles.VttFormatterSpec do
     end
   end
 end
+

--- a/spec/srt/parser_spec.exs
+++ b/spec/srt/parser_spec.exs
@@ -1,12 +1,12 @@
-defmodule Subtitles.SrtParserSpec do
+defmodule Subtitles.Srt.ParserSpec do
   use ESpec
 
   describe "#parse" do
-    subject do: sub() |> Subtitles.SrtParser.parse()
+    subject do: sub() |> Subtitles.Srt.Parser.parse()
 
     describe "valid sub" do
       let :sub, do: File.read!("spec/fixtures/test.srt")
-      let :expected, do: %Subtitle{
+      let :expected, do: {:ok, %Subtitle{
         cues: [
           %Cue{
             from: ~T[00:01:40.760],
@@ -46,14 +46,14 @@ defmodule Subtitles.SrtParserSpec do
             ]
           }
         ]
-      }
+      }}
 
       it do: should eq expected()
-    end 
+    end
 
     describe "crlf subtitle" do
       let :sub, do: "1\r\n00:00:00,000 --> 00:00:02,040\r\nThis is the sub text\r\n\r\n"
-      let :expected, do: %Subtitle{
+      let :expected, do: {:ok, %Subtitle{
         cues: [
           %Cue{
             from: ~T[00:00:00.000],
@@ -63,14 +63,14 @@ defmodule Subtitles.SrtParserSpec do
             ]
           }
         ]
-      }
+      }}
 
       it do: should eq expected()
     end
 
     describe "with leading newline" do
       let :sub, do: "\n1\n00:00:00,000 --> 00:00:02,040\nThis is the sub text\n\n"
-      let :expected, do: %Subtitle{
+      let :expected, do: {:ok, %Subtitle{
         cues: [
           %Cue{
             from: ~T[00:00:00.000],
@@ -80,7 +80,7 @@ defmodule Subtitles.SrtParserSpec do
             ]
           }
         ]
-      }
+      }}
 
       it do: should eq expected()
     end

--- a/spec/subtitles_spec.exs
+++ b/spec/subtitles_spec.exs
@@ -1,40 +1,43 @@
 defmodule SubtitlesSpec do
   use ESpec
 
+  alias Subtitles.Srt
+  alias Subtitles.Vtt
+
   let :vtt, do: File.read!("spec/fixtures/test.vtt")
   let :srt, do: File.read!("spec/fixtures/test.srt")
 
-  describe "#get_format/1" do
-    subject do: sub() |> Subtitles.get_format()
-    
+  describe "#guess_format/1" do
+    subject do: sub() |> Subtitles.guess_format()
+
     context "given a webvtt string" do
       let :sub, do: vtt()
 
-      it do: should eq :vtt
+      it do: should eq :Vtt
     end
 
     context "given an srt string" do
       let :sub, do: srt()
 
-      it do: should eq :srt
+      it do: should eq :Srt
     end
 
     context "given an srt with CRLF" do
       let :sub, do: "1\r\n00:00:00,000 --> 00:00:01,000\nsome text.\n\n"
 
-      it do: should eq :srt
+      it do: should eq :Srt
     end
 
     context "given an srt with optional leading newline" do
       let :sub, do: "\n1\n00:00:00,000 --> 00:00:01,000\nsome text.\n\n"
 
-      it do: should eq :srt
+      it do: should eq :Srt
     end
 
     context "given any other string" do
       let :sub, do: "some random string not matching any other format"
 
-      it do: should eq :unknown
+      it do: should eq :UnknownFormat
     end
   end
 
@@ -42,8 +45,8 @@ defmodule SubtitlesSpec do
     subject do: sub() |> Subtitles.parse()
 
     before do
-      allow Subtitles.VttParser |> to(accept :parse, fn _ -> :vtt end)
-      allow Subtitles.SrtParser |> to(accept :parse, fn _ -> :srt end)
+      allow Vtt.Parser |> to(accept :parse, fn _ -> {:ok, :vtt} end)
+      allow Srt.Parser |> to(accept :parse, fn _ -> {:ok, :srt} end)
     end
 
     context "given a webvtt" do
@@ -51,7 +54,7 @@ defmodule SubtitlesSpec do
 
       it do
         should eq {:ok, :vtt}
-        expect Subtitles.VttParser |> to(accepted :parse)
+        expect Vtt.Parser |> to(accepted :parse)
       end
     end
 
@@ -60,7 +63,7 @@ defmodule SubtitlesSpec do
 
       it do
         should eq {:ok, :srt}
-        expect Subtitles.SrtParser |> to(accepted :parse)
+        expect Srt.Parser |> to(accepted :parse)
       end
     end
 
@@ -75,32 +78,26 @@ defmodule SubtitlesSpec do
     subject do: "" |> Subtitles.parse(type())
 
     before do
-      allow Subtitles.VttParser |> to(accept :parse, fn _ -> :vtt end)
-      allow Subtitles.SrtParser |> to(accept :parse, fn _ -> :srt end)
+      allow Vtt.Parser |> to(accept :parse, fn _ -> {:ok, :vtt} end)
+      allow Srt.Parser |> to(accept :parse, fn _ -> {:ok, :srt} end)
     end
 
-    context "given :vtt" do
-      let :type, do: :vtt
+    context "given Vtt" do
+      let :type, do: :Vtt
 
       it do
         should eq {:ok, :vtt}
-        expect Subtitles.VttParser |> to(accepted :parse)
+        expect Vtt.Parser |> to(accepted :parse)
       end
     end
 
-    context "given :srt" do
-      let :type, do: :srt
+    context "given Srt" do
+      let :type, do: :Srt
 
       it do
         should eq {:ok, :srt}
-        expect Subtitles.SrtParser |> to(accepted :parse)
+        expect Srt.Parser |> to(accepted :parse)
       end
-    end
-
-    context "given :unknown" do
-      let :type, do: :unknown
-
-      it do: should eq {:error, "Unknown subtitle format"}
     end
   end
 end

--- a/spec/vtt/formatter_spec.exs
+++ b/spec/vtt/formatter_spec.exs
@@ -1,10 +1,10 @@
-defmodule Subtitles.SrtFormatterSpec do
+defmodule Subtitles.Vtt.FormatterSpec do
   use ESpec
 
   describe "#format" do
-    subject do: sub() |> Subtitles.SrtFormatter.format()
+    subject do: sub() |> Subtitles.Vtt.Formatter.format()
 
-    let :expected, do: File.read!("spec/fixtures/test.srt")
+    let :expected, do: File.read!("spec/fixtures/format_test.vtt")
     let :sub, do: %Subtitle{
       cues: [
         %Cue{
@@ -52,4 +52,3 @@ defmodule Subtitles.SrtFormatterSpec do
     end
   end
 end
-

--- a/spec/vtt/parser_spec.exs
+++ b/spec/vtt/parser_spec.exs
@@ -1,12 +1,12 @@
-defmodule Subtitles.VttParserSpec do
+defmodule Subtitles.Vtt.ParserSpec do
   use ESpec
 
   describe "#parse" do
-    subject do: sub() |> Subtitles.VttParser.parse()
+    subject do: sub() |> Subtitles.Vtt.Parser.parse()
 
     describe "valid sub" do
       let :sub, do: File.read!("spec/fixtures/test.vtt")
-      let :expected, do: %Subtitle{
+      let :expected, do: {:ok, %Subtitle{
         cues: [
           %Cue{
             from: ~T[00:00:00.000],
@@ -40,14 +40,14 @@ defmodule Subtitles.VttParserSpec do
             ]
           }
         ]
-      }
+      }}
 
       it do: should eq expected()
     end
 
     describe "crlf subtitle" do
       let :sub, do: "WEBVTT\r\n\r\n00:00:00.000 --> 00:00:02.040\r\nThis is the sub text\r\n\r\n"
-      let :expected, do: %Subtitle{
+      let :expected, do: {:ok, %Subtitle{
         cues: [
           %Cue{
             from: ~T[00:00:00.000],
@@ -57,7 +57,7 @@ defmodule Subtitles.VttParserSpec do
             ]
           }
         ]
-      }
+      }}
 
       it do: should eq expected()
     end


### PR DESCRIPTION
I hope I'm not stepping on any toes here, but after seeing a failure in usage where invalid UTF on input yielded a cryptic error on output, I started skimming through the code, and came to (what I believe is) some improvements.

1. Subtitles.parse did not validate input at all, before parsing. Now does
   at least basic UTF-8 sanity check.
2. The Parser.parse interface had no way of signaling error. That parsing
   will succeed because some quick probing returned the given format, is an
   invalid assumption
3. Rewrote the structure of parsers/formatters slightly to exploit the fact
   that modules in Elixir are also symbols, avoiding a need for additional
   symbols. (:srt vs. :Srt)
4. Parsing of explicitly unknown format should not be a public API, and
   should not be tested